### PR TITLE
Accessibility: add aria-current="page" to Home link in header, footer, and mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 <span class="font-display text-lg font-semibold tracking-wide">Team Combat USA DC</span>
 </a>
 <nav aria-label="Primary" class="hidden gap-6 md:flex">
-<a class="nav-link text-sm dark:text-slate-200" href="index.html">Home</a>
+<a class="nav-link text-sm dark:text-slate-200" href="index.html" aria-current="page">Home</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="warrior-ethos.html">Warrior‑Ethos</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="history.html">History</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="styles.html">Styles</a>
@@ -75,7 +75,7 @@
 <div class="absolute duration-200 h-[calc(100dvh-64px)] hidden w-full translate-y-[-16px] opacity-0 transition-all translate-y-[-8px] z-30" data-open="false" id="mobile-menu">
 <div class="mx-4 rounded-2xl border border-slate-200/60 bg-white/90 p-4 shadow-xl backdrop-blur dark:border-slate-800 dark:bg-slate-900/90">
 <nav aria-label="Mobile" class="grid gap-2 text-base">
-<a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="index.html">Home</a>
+<a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="index.html" aria-current="page">Home</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="warrior-ethos.html">Warrior‑Ethos</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="history.html">History</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="styles.html">Styles</a>
@@ -245,7 +245,7 @@
 <span class="font-display text-lg font-semibold">Team Combat USA DC</span>
 </div>
 <nav aria-label="Primary" class="hidden gap-6 md:flex">
-<a class="nav-link text-sm dark:text-slate-200" href="index.html">Home</a>
+<a class="nav-link text-sm dark:text-slate-200" href="index.html" aria-current="page">Home</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="warrior-ethos.html">Warrior‑Ethos</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="history.html">History</a>
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="styles.html">Styles</a>


### PR DESCRIPTION
### What changed
- Added `aria-current="page"` to the "Home" link in:
  - Header navigation
  - Mobile drawer navigation
  - Footer navigation

### Why
- Improves accessibility by letting assistive technology announce that "Home" is the current page.
- No visual changes, just semantic improvement.

### Testing
- Verified on the dev preview site:
  - All three "Home" links now include `aria-current="page"`.
  - Keyboard navigation still works normally.
  - Screen readers / DevTools Accessibility pane recognize "Home" as the current page.

This is Step #1 of our planned micro-commits for improving index.html.
