### PR TITLE
Step 2: Fix Tailwind class typos and remove duplicate CSS link

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       }
     </script><link href="assets/site.css" rel="stylesheet"/>
 <link href="/css/proposed-font-standardization.css" rel="stylesheet"/>
-<link href="/css/typography.css" rel="stylesheet"/><link href="https://fonts.googleapis.com/css2?family=Antonio:wght@400;600;700&amp;family=Inter:wght@400;600;800&amp;display=swap" rel="stylesheet"/><link href="/css/typography.css" rel="stylesheet"/></head>
+<link href="/css/typography.css" rel="stylesheet"/><link href="https://fonts.googleapis.com/css2?family=Antonio:wght@400;600;700&amp;family=Inter:wght@400;600;800&amp;display=swap" rel="stylesheet"/></head>
 <body class="min-h-dvh bg-white text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100 font-body typography-v1">
 <a class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-white focus:px-3 focus:py-2 focus:text-slate-900" href="#main">Skip to content</a>
 <!-- Header / Navbar -->
@@ -214,7 +214,7 @@
 </article>
 <article class="rounded-xl border border-slate-200/60 bg-white p-5 shadow-card dark:border-slate-800 dark:bg-slate-900">
 <h3 class="font-semibold"><a class="hover:text-brand-700" href="inspiration.html">Inspiration</a></h3>
-<p class="mt-1 text_sm text-slate-600 dark:text-slate-300">Principles and prompts that keep you consistent.</p>
+<p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Principles and prompts that keep you consistent.</p>
 </article>
 </div>
 </section>
@@ -240,8 +240,8 @@
 <footer class="mt-16 border-t border-slate-200/60 bg-slate-50/60 py-10 dark:border-slate-800 dark:bg-slate-900/40">
 <div class="mx-auto max-w-screen-xl px-4">
 <div class="flex flex-col items-start justify-between gap-8 md:flex-row md:items-center">
-<div class="flex items_center gap-2">
-<span class="inline-flex h-9 w-9 items-center justify_center rounded-xl bg-brand-700 text-white">TC</span>
+<div class="flex items-center gap-2">
+<span class="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-brand-700 text-white">TC</span>
 <span class="font-display text-lg font-semibold">Team Combat USA DC</span>
 </div>
 <nav aria-label="Primary" class="hidden gap-6 md:flex">


### PR DESCRIPTION
- items_center → items-center
- justify_center → justify-center
- text_sm → text-sm
- Remove duplicate <link href="/css/typography.css"> in <head>

Impact:
- Proper centering of the “TC” badge
- Consistent text sizing on cards
- Avoid redundant CSS request