### PR TITLE
Step 3: Add sun/moon icons and focus ring to dark-mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,18 @@
 <a class="nav-link text-slate-700 hover:text-brand-700 text-sm dark:text-slate-200" href="inspiration.html">Inspiration</a>
 </nav>
 <div class="flex items-center gap-2 md:gap-3">
-<button aria-label="Toggle dark mode" class="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200/60 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900" id="theme-toggle" type="button"></button>
++<button
++  aria-label="Toggle dark mode"
++  id="theme-toggle"
++  type="button"
++  class="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200/60 bg-white text-slate-700 hover:bg-slate-50
++         focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-white
++         dark:border-slate-800 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900 dark:focus:ring-offset-slate-950">
++  <!-- Sun (light mode) -->
++  <svg class="h-5 w-5 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
++  <!-- Moon (dark mode) -->
++  <svg class="hidden h-5 w-5 dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
++</button>
 <button aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200/60 bg-white text-slate-700 hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900" id="menu-toggle" type="button">
 <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 6h16M4 12h16M4 18h16"></path></svg>
 </button>


### PR DESCRIPTION
- Inserted inline SVG icons inside #theme-toggle
  - Sun (visible in light mode, class="h-5 w-5 dark:hidden")
  - Moon (visible in dark mode, class="hidden h-5 w-5 dark:block")
- Added focus styles for accessibility: focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 (and dark offset)

Impact:
- Screen readers now announce "Toggle dark mode"
- Keyboard users see a clear focus indicator
- Visual affordance: sun/moon icons reflect the theme state
- No JavaScript changes (purely HTML/CSS tweak)