### PR TITLE
Fix duplicate <head> in standing.html

### DIFF
--- a/standing.html
+++ b/standing.html
@@ -7,7 +7,6 @@
 <link href="/css/typography.css" rel="stylesheet">
 <link href="/css/proposed-font-standardization.css" rel="stylesheet">
 
-<head>
    <meta charset="utf-8"/>
    <meta content="width=device-width, initial-scale=1" name="viewport"/>
    <title>
@@ -49,7 +48,6 @@
   
   
   
-  <link href="https://fonts.googleapis.com/css2?family=Antonio:wght@400;600;700&amp;family=Inter:wght@400;600;800&amp;display=swap" rel="stylesheet"/>
  </head>
  <body class="min-h-dvh bg-white text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100 font-body typography-v1">
   <a


### PR DESCRIPTION
Removed an extra <head> tag and stray <link> from standing.html to ensure valid HTML structure.  
- Consolidated to a single <head> block at the top of the document  
- Prevents potential browser parsing quirks and duplicate stylesheet loads  
- No visual or functional changes expected
