### PR TITLE
chore(seo): add noindex,nofollow to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,6 +9,7 @@
 
 <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
   <title>Page Not Found — Team Combat USA DC</title>
   <meta name="description" content="That page doesn’t exist.">
   <meta name="theme-color" content="#7f1d1d">

--- a/404.html
+++ b/404.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
 <html class="scroll-smooth" lang="en">
-<head><link rel="preconnect" href="https://fonts.googleapis.com">
+<head>
+<meta charset="utf-8">  
+<link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Antonio:wght@400;600;700&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
 <link href="/assets/site.css" rel="stylesheet">
 <link href="/css/typography.css" rel="stylesheet">
 <link href="/css/proposed-font-standardization.css" rel="stylesheet">
-
-<meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, nofollow">
+  <meta name="googlebot" content="noindex, nofollow">
   <title>Page Not Found — Team Combat USA DC</title>
   <meta name="description" content="That page doesn’t exist.">
   <meta name="theme-color" content="#7f1d1d">


### PR DESCRIPTION
Add robots noindex, nofollow to 404.html so error pages aren’t indexed.

Keeps sitemap/canonical out of 404.

No other content changes.