### PR TITLE
htaccess docs are reference-only and not part of the site build.

### DIFF
--- a/docs/htaccess-dev.sample
+++ b/docs/htaccess-dev.sample
@@ -1,3 +1,5 @@
+# Reference only — copied into hosting env; not used by build
+
 ErrorDocument 404 /404.html
 Header always set Content-Security-Policy: upgrade-insecure-requests
 RewriteEngine On

--- a/docs/htaccess-prod.sample
+++ b/docs/htaccess-prod.sample
@@ -1,3 +1,5 @@
+docs(ops): mark htaccess files as reference-only
+
 # Begin cache control #
 ErrorDocument 404 /404.html
 ExpiresActive on


### PR DESCRIPTION
place these in .htaccess files in prod and dev sites