### PR TITLE
feat(home): move hero outside <main> for full-bleed layout; match sitewide hero pattern; preserve copy & CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
       Home
     </h1>
     <p class="mt-3 max-w-prose text-white/90 md:text-lg">
-      The purpose of this site is to share an overview of our training, curriculum, and ethos to fellow warriors.
+      The purpose of this site is to provide an overview of our training, curriculum, and ethos.
     </p>
     <div class="mt-6 flex flex-wrap gap-3">
       <a

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
       Home
     </h1>
     <p class="mt-3 max-w-prose text-white/90 md:text-lg">
-      The purpose of this site is to share an overview of our training, curriculum, and ethos to fellow warriors.
+      The purpose of this site is to provide to Team Combat USA students an overview of our training, curriculum, and ethos.
     </p>
     <div class="mt-6 flex flex-wrap gap-3">
       <a class="inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2 font-semibold text-brand-700 hover:bg-slate-100" href="/fundamentals.html">

--- a/index.html
+++ b/index.html
@@ -159,17 +159,29 @@
 </header>
 <main class="py-8 container px-4 max-w-6xl lg:px-8 sm:px-6 mx-auto" id="main" tabindex="-1">
 <!-- Hero -->
-<section class="relative isolate overflow-hidden bg-gradient-to-b from-brand-800 to-brand-700 py-16 text-white">
-<div class="mx-auto max-w-screen-xl px-4">
-<div class="max-w-2xl">
-<h1 class="text-4xl md:text-5xl font-bold font-extrabold leading-tight sm:text-5xl font-display md:text-6xl text-3xl">
-       Home
-      </h1>
-<p class="mt-3 max-w-prose text-white/90 md:text-lg">
-       The purpose of this site is to share an overview of our training, curriculum, and ethos to fellow warriors.
-      </p>
-</div>
-</div>
+<section class="bg-brand-700 py-16 text-white">
+  <div class="mx-auto max-w-6xl px-6">
+    <h1 class="font-display text-4xl font-extrabold leading-tight sm:text-5xl md:text-6xl">
+      Home
+    </h1>
+    <p class="mt-3 max-w-prose text-white/90 md:text-lg">
+      The purpose of this site is to share an overview of our training, curriculum, and ethos to fellow warriors.
+    </p>
+    <div class="mt-6 flex flex-wrap gap-3">
+      <a
+        class="inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2 font-semibold text-brand-700 hover:bg-slate-100"
+        href="/fundamentals.html"
+      >
+        Start with Fundamentals
+      </a>
+      <a
+        class="inline-flex items-center gap-2 rounded-xl border border-white/70 px-4 py-2 font-semibold text-white hover:bg-white/10"
+        href="/self-defense.html"
+      >
+        See Self-Defense
+      </a>
+    </div>
+  </div>
 </section>
 
 <!-- Feature photo -->

--- a/index.html
+++ b/index.html
@@ -158,30 +158,36 @@
 </div>
 </header>
 <main class="py-8 container px-4 max-w-6xl lg:px-8 sm:px-6 mx-auto" id="main" tabindex="-1">
-<!-- HERO pulled from  language -->
-<section class="p-0 border-slate-200/60 flow dark:border-slate-800 relative overflow-hidden rounded-2xl dark:bg-slate-900/40 bg-slate-50/60 border">
-<div class="relative h-72 w-full">
-<div class="absolute inset-0 bg-gradient-to-t from-slate-950/70 to-transparent">
-</div>
-<div class="inset-x-0 p-6 bottom-0 md:p-8 absolute flow">
-<h1 class="font-display text-3xl font-extrabold leading-tight sm:text-4xl">
-       Principle‑driven training for real‑world skill.
+<!-- HERO -->
+<section class="flow border border-slate-200/60 rounded-2xl bg-slate-50/60 dark:border-slate-800 dark:bg-slate-900/40 relative overflow-hidden">
+  <div class="relative">
+    <div class="absolute inset-0 bg-gradient-to-t from-slate-950/70 to-transparent"></div>
+
+    <div class="relative z-10 p-6 md:p-8">
+      <h1 class="font-display text-3xl font-extrabold leading-tight sm:text-4xl text-white">
+        Home
       </h1>
-<p class="text-base opacity-90">The purpose of this site is to provide an overview of our training principles, curriculum, and ethos.</p>
-<p class="mt-3 max-w-2xl text-slate-200">
-       Build base and posture, frames and movement, then pressure‑test through standing, clinch, and ground.
+
+      <p class="text-base opacity-90 text-slate-200">
+        The purpose of this site is to provide an overview of our training principles, curriculum, and ethos.
       </p>
-<div class="mt-4 flex gap-3">
-<a class="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-4 py-2 font-semibold text-white hover:bg-brand-800" href="/fundamentals.html">
-        Start with Fundamentals
-       </a>
-<a class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-white/90 px-4 py-2 font-semibold hover:bg-white dark:border-slate-800 dark:bg-slate-900/60" href="/self-defense.html">
-        See Self‑Defense
-       </a>
-</div>
-</div>
-</div>
+
+      <p class="mt-3 max-w-2xl text-slate-200">
+        Build base and posture, frames and movement, then pressure-test through standing, clinch, and ground.
+      </p>
+
+      <div class="mt-4 flex gap-3">
+        <a class="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-4 py-2 font-semibold text-white hover:bg-brand-800" href="/fundamentals.html">
+          Start with Fundamentals
+        </a>
+        <a class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-white/90 px-4 py-2 font-semibold hover:bg-white dark:border-slate-800 dark:bg-slate-900/60" href="/self-defense.html">
+          See Self-Defense
+        </a>
+      </div>
+    </div>
+  </div>
 </section>
+
 <!-- Feature photo -->
 <section class="mt-10">
 <div class="mx-auto max-w-5xl px-4">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-
 <html class="scroll-smooth" lang="en">
 <head>
   <script>
@@ -127,7 +126,7 @@
 
 <!-- Mobile menu toggle (no data-menu-toggle) -->
 <button aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu" class="md:hidden inline-flex h-9 w-9 items-center justify-center rounded-xl border border-slate-200/60 text-slate-900 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-100 dark:hover:bg-slate-800" id="menu-toggle" type="button">
-<svg aria-hidden="true" class="h-5 w-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.25" viewbox="0 0 24 24">
+<svg aria-hidden="true" class="h-5 w-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.25" viewBox="0 0 24 24">
 <path d="M4 6h16M4 12h16M4 18h16"></path>
 </svg>
 </button>
@@ -157,33 +156,28 @@
 </div>
 </div>
 </header>
-<main class="py-8 container px-4 max-w-6xl lg:px-8 sm:px-6 mx-auto" id="main" tabindex="-1">
-<!-- Hero -->
+
+<!-- Hero (full-bleed, matches interior pages) -->
 <section class="bg-brand-700 py-16 text-white">
   <div class="mx-auto max-w-6xl px-6">
     <h1 class="font-display text-4xl font-extrabold leading-tight sm:text-5xl md:text-6xl">
       Home
     </h1>
     <p class="mt-3 max-w-prose text-white/90 md:text-lg">
-      The purpose of this site is to provide an overview of our training, curriculum, and ethos.
+      The purpose of this site is to share an overview of our training, curriculum, and ethos to fellow warriors.
     </p>
     <div class="mt-6 flex flex-wrap gap-3">
-      <a
-        class="inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2 font-semibold text-brand-700 hover:bg-slate-100"
-        href="/fundamentals.html"
-      >
+      <a class="inline-flex items-center gap-2 rounded-xl bg-white px-4 py-2 font-semibold text-brand-700 hover:bg-slate-100" href="/fundamentals.html">
         Start with Fundamentals
       </a>
-      <a
-        class="inline-flex items-center gap-2 rounded-xl border border-white/70 px-4 py-2 font-semibold text-white hover:bg-white/10"
-        href="/self-defense.html"
-      >
+      <a class="inline-flex items-center gap-2 rounded-xl border border-white/70 px-4 py-2 font-semibold text-white hover:bg-white/10" href="/self-defense.html">
         See Self-Defense
       </a>
     </div>
   </div>
 </section>
 
+<main class="py-8 container px-4 max-w-6xl lg:px-8 sm:px-6 mx-auto" id="main" tabindex="-1">
 <!-- Feature photo -->
 <section class="mt-10">
 <div class="mx-auto max-w-5xl px-4">

--- a/index.html
+++ b/index.html
@@ -158,34 +158,18 @@
 </div>
 </header>
 <main class="py-8 container px-4 max-w-6xl lg:px-8 sm:px-6 mx-auto" id="main" tabindex="-1">
-<!-- HERO -->
-<section class="flow border border-slate-200/60 rounded-2xl bg-slate-50/60 dark:border-slate-800 dark:bg-slate-900/40 relative overflow-hidden">
-  <div class="relative">
-    <div class="absolute inset-0 bg-gradient-to-t from-slate-950/70 to-transparent"></div>
-
-    <div class="relative z-10 p-6 md:p-8">
-      <h1 class="font-display text-3xl font-extrabold leading-tight sm:text-4xl text-white">
-        Home
+<!-- Hero -->
+<section class="relative isolate overflow-hidden bg-gradient-to-b from-brand-800 to-brand-700 py-16 text-white">
+<div class="mx-auto max-w-screen-xl px-4">
+<div class="max-w-2xl">
+<h1 class="text-4xl md:text-5xl font-bold font-extrabold leading-tight sm:text-5xl font-display md:text-6xl text-3xl">
+       Home
       </h1>
-
-      <p class="text-base opacity-90 text-slate-200">
-        The purpose of this site is to provide an overview of our training principles, curriculum, and ethos.
+<p class="mt-3 max-w-prose text-white/90 md:text-lg">
+       The purpose of this site is to share an overview of our training, curriculum, and ethos to fellow warriors.
       </p>
-
-      <p class="mt-3 max-w-2xl text-slate-200">
-        Build base and posture, frames and movement, then pressure-test through standing, clinch, and ground.
-      </p>
-
-      <div class="mt-4 flex gap-3">
-        <a class="inline-flex items-center gap-2 rounded-xl bg-brand-700 px-4 py-2 font-semibold text-white hover:bg-brand-800" href="/fundamentals.html">
-          Start with Fundamentals
-        </a>
-        <a class="inline-flex items-center gap-2 rounded-xl border border-slate-200/60 bg-white/90 px-4 py-2 font-semibold hover:bg-white dark:border-slate-800 dark:bg-slate-900/60" href="/self-defense.html">
-          See Self-Defense
-        </a>
-      </div>
-    </div>
-  </div>
+</div>
+</div>
 </section>
 
 <!-- Feature photo -->


### PR DESCRIPTION
Converted Home hero to the full-bleed sitewide pattern (outside <main>)

Solid brand banner with proper container (max-w-6xl, px-6, py-16)

Kept exact copy and buttons

Fixes prior mobile clipping by using content-driven height